### PR TITLE
feat: validate expr result type; better error filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,3 +252,5 @@ If you need to create arrays of arrays, wrap it in another array to get around t
 2. Should `nil` results from interpolation be rendered in the final output? Example: `name: ${name}` and what if `name` is `nil`?
 
 3. Support for constants? Values that should always be present in the params that can contain complex and reusable data for the template?
+
+4. Ability to sort `$for` loop output based on some expr?

--- a/cmd/sdt/main.go
+++ b/cmd/sdt/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	// Validate template output format
-	if errs := doc.ValidateTemplate(os.Args[1]); len(errs) > 0 {
+	if errs := doc.ValidateTemplate(); len(errs) > 0 {
 		fmt.Println("Error while validating template:")
 		for _, err := range errs {
 			fmt.Println(err)
@@ -42,7 +42,7 @@ func main() {
 	}
 
 	// Validate params from bp.Schema
-	if err := doc.ValidateInput(os.Args[1], params); err != nil {
+	if err := doc.ValidateInput(params); err != nil {
 		fmt.Println("Error while validating input params:")
 		fmt.Println(err)
 		os.Exit(1)
@@ -59,7 +59,7 @@ func main() {
 	}
 
 	// Confirm that the output conforms to the schema now that it's rendered.
-	if err := doc.ValidateOutput(os.Args[1], rendered); err != nil {
+	if err := doc.ValidateOutput(rendered); err != nil {
 		fmt.Println("Error validating rendered output:")
 		fmt.Println(err)
 		os.Exit(1)

--- a/context.go
+++ b/context.go
@@ -10,27 +10,42 @@ type errors struct {
 }
 
 type context struct {
-	Path   string
-	Errors *errors
+	Filename string
+	Path     string
+	Errors   *errors
 }
 
-func newContext() *context {
+func newContext(filename string, path ...string) *context {
 	return &context{
-		Path:   "/",
-		Errors: &errors{},
+		Filename: filename,
+		Path:     "/" + strings.Join(path, "/"),
+		Errors:   &errors{},
 	}
 }
 
 func (c *context) WithPath(path interface{}) *context {
 	return &context{
-		Path:   strings.TrimRight(c.Path, "/") + "/" + fmt.Sprintf("%v", path),
-		Errors: c.Errors,
+		Filename: c.Filename,
+		Path:     strings.TrimRight(c.Path, "/") + "/" + fmt.Sprintf("%v", path),
+		Errors:   c.Errors,
 	}
+}
+
+// FullPath returns the full path to the context, including the filename if
+// one was given.
+func (c *context) FullPath() string {
+	if c.Filename != "" {
+		if strings.Contains(c.Filename, "#") {
+			return c.Filename + c.Path
+		}
+		return c.Filename + "#" + c.Path
+	}
+	return c.Path
 }
 
 // AddError adds an error into the rendering context at the current path. As
 // a convenience it returns nil.
 func (c *context) AddError(err error) interface{} {
-	c.Errors.Value = append(c.Errors.Value, fmt.Errorf("%s: %w", c.Path, err))
+	c.Errors.Value = append(c.Errors.Value, fmt.Errorf("%s: %w", c.FullPath(), err))
 	return nil
 }

--- a/fixtures/dynamic_type_mismatch.yaml
+++ b/fixtures/dynamic_type_mismatch.yaml
@@ -16,5 +16,5 @@ tests:
   - input:
       foo: some test value
     errors:
-      - expected boolean, but got string
+      - results in string but expecting [boolean]
     expected: {}

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -69,14 +69,15 @@ func TestFixtures(t *testing.T) {
 				t.Error(err)
 				return
 			}
+			f.Document.Filename = filename + "#/document"
 
 			for i, test := range f.Tests {
 				t.Run(fmt.Sprintf("%s-%d-%s", file.Name(), i, test.Name), func(t *testing.T) {
-					if test.ErrorsFail(t, f.Document.ValidateTemplate(filename)) {
+					if test.ErrorsFail(t, f.Document.ValidateTemplate()) {
 						return
 					}
 
-					err := f.Document.ValidateInput(filename, test.Input)
+					err := f.Document.ValidateInput(test.Input)
 					if err != nil && test.ErrorsFail(t, []error{err}) {
 						return
 					}
@@ -86,7 +87,7 @@ func TestFixtures(t *testing.T) {
 						return
 					}
 
-					err = f.Document.ValidateOutput(filename, out)
+					err = f.Document.ValidateOutput(out)
 					if err != nil && test.ErrorsFail(t, []error{err}) {
 						return
 					}


### PR DESCRIPTION
This enables the validator to make sure the result of an expression is the right type based on the output schema. Before this was only possible at rendering time, not validation time.

It also fixes the filenames in errors and allows the original filename to include a JSON path `#/foo/bar` which is appended to. This is useful for documents loaded from within other documents like we do with the test fixtures.