### PR TITLE
feat: add explicit $flatten operation

### DIFF
--- a/document.go
+++ b/document.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"path"
 
-	_ "github.com/santhosh-tekuri/jsonschema/v5/httploader"
 	"gopkg.in/yaml.v3"
 )
 
@@ -52,7 +51,7 @@ func NewFromFile(filename string) (*Document, error) {
 	return doc, nil
 }
 
-// Validate that input params are correct based on the schema.
+// ValidateInput validates that input params are correct based on the schema.
 func (doc *Document) ValidateInput(params map[string]interface{}) error {
 	if doc.Schemas == nil || doc.Schemas.Input == nil {
 		return nil
@@ -76,6 +75,8 @@ func (doc *Document) ValidateInput(params map[string]interface{}) error {
 	return nil
 }
 
+// ValidateTemplate validates that the template is structurally and semantically
+// correct based on the given schemas.
 func (doc *Document) ValidateTemplate() []error {
 	if doc.Schemas == nil || doc.Schemas.Input == nil {
 		return []error{fmt.Errorf("input schema required")}
@@ -106,6 +107,7 @@ func (doc *Document) ValidateTemplate() []error {
 	return ctx.Errors.Value
 }
 
+// ValidateOutput validates the rendered output against the given output schema.
 func (doc *Document) ValidateOutput(output interface{}) error {
 	if doc.Schemas == nil || doc.Schemas.Output == nil {
 		return nil

--- a/fixtures/flatten.yaml
+++ b/fixtures/flatten.yaml
@@ -1,0 +1,38 @@
+document:
+  schemas:
+    input:
+      type: object
+      properties:
+        numbers:
+          type: array
+          items:
+            type: number
+            minimum: 2
+    output:
+      type: object
+      properties:
+        squares:
+          type: array
+          items:
+            type: number
+  template:
+    squares:
+      # This is obviously a contrived monstrosity for testing - avoid such
+      # complexity in your own templates if you can!
+      $flatten:
+        - - 0
+          - 1
+        - $flatten:
+            $for: ${numbers}
+            $each:
+              $flatten:
+                - - ${item}
+                - $if: true
+                  $then:
+                    - ${item * item}
+        - - 100
+tests:
+  - input:
+      numbers: [2, 3, 4]
+    expected:
+      squares: [0, 1, 2, 4, 3, 9, 4, 16, 100]

--- a/fixtures/looping.yaml
+++ b/fixtures/looping.yaml
@@ -24,7 +24,9 @@ document:
         prices:
           type: array
           items:
-            type: number
+            type: array
+            items:
+              type: number
   template:
     names:
       $for: ${things}
@@ -45,7 +47,7 @@ tests:
           price: 10
     expected:
       names: [Thing 1, Thing 2]
-      prices: [25, 50, 75, 10, 20, 30]
+      prices: [[25, 50, 75], [10, 20, 30]]
   - name: just_name
     input:
       things:
@@ -53,7 +55,7 @@ tests:
         - name: Thing 2
     expected:
       names: [Thing 1, Thing 2]
-      prices: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      prices: [[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]
   - name: empty
     input: {}
     expected: {}

--- a/validate.go
+++ b/validate.go
@@ -9,6 +9,9 @@ import (
 
 	"github.com/antonmedv/expr"
 	"github.com/santhosh-tekuri/jsonschema/v5"
+
+	// Enable loading schemas via HTTP references.
+	_ "github.com/santhosh-tekuri/jsonschema/v5/httploader"
 )
 
 func hasType(s *jsonschema.Schema, typ string) bool {
@@ -103,6 +106,141 @@ func getJSONType(value interface{}) string {
 	}[reflect.TypeOf(value).Kind()]
 }
 
+func validateString(ctx *context, s *jsonschema.Schema, template interface{}, paramsExample map[string]interface{}) {
+	matches := interpolationRe.FindAllString(template.(string), -1)
+
+	if len(matches) > 0 {
+		for _, match := range matches {
+			_, err := expr.Compile(match[2:len(match)-1], expr.Env(paramsExample))
+			if err != nil {
+				ctx.AddError(fmt.Errorf("error validating template: unable to compile expression '%s': %v", match, err))
+			}
+		}
+	}
+
+	if len(matches) == 1 && len(matches[0]) == len(template.(string)) {
+		// This is a single value string template that can return any type.
+		t := template.(string)
+		out, err := expr.Eval(t[2:len(t)-1], paramsExample)
+		if err != nil {
+			ctx.AddError(fmt.Errorf("error validating template: unable to eval expression '%s': %v", t[2:len(t)-1], err))
+			return
+		}
+		outJSONType := getJSONType(out)
+		if !hasType(s, outJSONType) {
+			if outJSONType == "number" && hasType(s, "integer") {
+				// Parsed static numbers are always float64 for some input formats
+				// like JSON. We can safely ignore this because it should render
+				// correctly in the output.
+				return
+			}
+			ctx.AddError(fmt.Errorf("error validating template: expression '%s' results in %s but expecting %v", t[2:len(t)-1], outJSONType, s.Types))
+		}
+		return
+	}
+
+	// This will result in a string as output.
+	if !hasType(s, "string") {
+		ctx.AddError(fmt.Errorf("error validating template: string not allowed, expecting %v", s.Types))
+	}
+}
+
+func validateBranch(ctx *context, s *jsonschema.Schema, t map[string]interface{}, paramsExample map[string]interface{}) {
+	if t["$then"] == nil {
+		ctx.AddError(fmt.Errorf("error validating template:  $then clause is required for $if branching"))
+	} else {
+		validateTemplate(ctx.WithPath("$then"), s, t["$then"], paramsExample)
+	}
+	if t["$else"] != nil {
+		validateTemplate(ctx.WithPath("$else"), s, t["$else"], paramsExample)
+	}
+}
+
+func validateLoop(ctx *context, s *jsonschema.Schema, t map[string]interface{}, paramsExample map[string]interface{}) {
+
+	var item interface{}
+	switch v := t["$for"].(type) {
+	case string:
+		if !strings.HasPrefix(v, "${") {
+			ctx.AddError(fmt.Errorf("error validating template: $for expression must use ${...} interpolation syntax"))
+			return
+		}
+		results, err := expr.Eval(v[2:len(v)-1], paramsExample)
+		if err != nil {
+			ctx.AddError(fmt.Errorf("error validating template: unable to test $for expression: %v", err))
+			return
+		}
+
+		if a, ok := results.([]interface{}); ok {
+			item = a[0]
+		} else {
+			ctx.AddError((fmt.Errorf("error validating template: $for expresssion must result in an array but found '%v'", results)))
+			return
+		}
+	case []interface{}:
+		item = v[0]
+	default:
+		ctx.AddError(fmt.Errorf("error validating template: $for expression must be an array or string"))
+		return
+	}
+
+	if t["$each"] == nil {
+		ctx.AddError(fmt.Errorf("error validating template: $each clause is required for $for looping"))
+	} else {
+		paramsCopy := map[string]interface{}{}
+		for k, v := range paramsExample {
+			paramsCopy[k] = v
+		}
+
+		as := "item"
+		if t["$as"] != nil {
+			if s, ok := t["$as"].(string); ok {
+				as = s
+			} else {
+				ctx.AddError(fmt.Errorf("error validating template: $as must be a string"))
+				return
+			}
+		}
+
+		paramsCopy[as] = item
+
+		loop := "loop"
+		if as != "item" {
+			loop += "_" + as
+		}
+		paramsCopy[loop] = map[string]interface{}{
+			"index": 0,
+			"first": true,
+			"last":  false,
+		}
+
+		validateTemplate(ctx.WithPath("$each"), getItems(s), t["$each"], paramsCopy)
+	}
+}
+
+func validateFlatten(ctx *context, s *jsonschema.Schema, t map[string]interface{}, paramsExample map[string]interface{}) {
+	switch flat := t["$flatten"].(type) {
+	case []interface{}:
+		for i, item := range flat {
+			validateTemplate(ctx.WithPath(fmt.Sprintf("$flatten/%d", i)), s, item, paramsExample)
+		}
+		// TODO: disallow extra properties?
+		return
+	case map[string]interface{}:
+		if flat["$for"] != nil {
+			// This is okay because it'll evaluate to an array eventually. So the
+			// schema validation keeps working, wrap it in an array.
+			wrapped := &jsonschema.Schema{
+				Types: []string{"array"},
+				Items: s,
+			}
+			validateTemplate(ctx.WithPath("$flatten"), wrapped, flat, paramsExample)
+			return
+		}
+	}
+	ctx.AddError(fmt.Errorf("$flatten must be an array or contain a $for clause"))
+}
+
 func validateTemplate(ctx *context, s *jsonschema.Schema, template interface{}, paramsExample map[string]interface{}) {
 	if s == nil {
 		return
@@ -116,41 +254,7 @@ func validateTemplate(ctx *context, s *jsonschema.Schema, template interface{}, 
 
 	// Special case: string template
 	if jsonType == "string" {
-		matches := interpolationRe.FindAllString(template.(string), -1)
-
-		if len(matches) > 0 {
-			for _, match := range matches {
-				_, err := expr.Compile(match[2:len(match)-1], expr.Env(paramsExample))
-				if err != nil {
-					ctx.AddError(fmt.Errorf("error validating template: unable to compile expression '%s': %v", match, err))
-				}
-			}
-		}
-
-		if len(matches) == 1 && len(matches[0]) == len(template.(string)) {
-			// This is a single value string template that can return any type.
-			t := template.(string)
-			out, err := expr.Eval(t[2:len(t)-1], paramsExample)
-			if err != nil {
-				ctx.AddError(fmt.Errorf("error validating template: unable to eval expression '%s': %v", t[2:len(t)-1], err))
-			}
-			outJSONType := getJSONType(out)
-			if !hasType(s, outJSONType) {
-				if outJSONType == "number" && hasType(s, "integer") {
-					// Parsed static numbers are always float64 for some input formats
-					// like JSON. We can safely ignore this because it should render
-					// correctly in the output.
-					return
-				}
-				ctx.AddError(fmt.Errorf("error validating template: expression '%s' results in %s but expecting %v", t[2:len(t)-1], outJSONType, s.Types))
-			}
-			return
-		} else {
-			// This will result in a string as output.
-			if !hasType(s, "string") {
-				ctx.AddError(fmt.Errorf("error validating template: string not allowed, expecting %v", s.Types))
-			}
-		}
+		validateString(ctx, s, template, paramsExample)
 		return
 	}
 
@@ -159,94 +263,17 @@ func validateTemplate(ctx *context, s *jsonschema.Schema, template interface{}, 
 		t := template.(map[string]interface{})
 
 		if t["$if"] != nil {
-			if t["$then"] == nil {
-				ctx.AddError(fmt.Errorf("error validating template:  $then clause if required for $if branching"))
-			} else {
-				validateTemplate(ctx.WithPath("$then"), s, t["$then"], paramsExample)
-			}
-			if t["$else"] != nil {
-				validateTemplate(ctx.WithPath("$else"), s, t["$else"], paramsExample)
-			}
-			// TODO: disallow extra properties?
+			validateBranch(ctx, s, t, paramsExample)
 			return
 		}
 
 		if t["$for"] != nil {
-			var item interface{}
-			switch v := t["$for"].(type) {
-			case string:
-				if !strings.HasPrefix(v, "${") {
-					ctx.AddError(fmt.Errorf("error validating template: $for expression must use ${...} interpolation syntax"))
-					return
-				}
-				results, err := expr.Eval(v[2:len(v)-1], paramsExample)
-				if err != nil {
-					ctx.AddError(fmt.Errorf("error validating template: unable to test $for expression: %v", err))
-					return
-				}
+			validateLoop(ctx, s, t, paramsExample)
+			return
+		}
 
-				if a, ok := results.([]interface{}); ok {
-					item = a[0]
-				} else {
-					ctx.AddError((fmt.Errorf("error validating template: $for expresssion must result in an array but found '%v'", results)))
-					return
-				}
-			case []interface{}:
-				item = v[0]
-			default:
-				ctx.AddError(fmt.Errorf("error validating template: $for expression must be an array or string"))
-				return
-			}
-
-			if t["$each"] == nil {
-				ctx.AddError(fmt.Errorf("error validating template: $each clause is required for $for looping"))
-			} else {
-				paramsCopy := map[string]interface{}{}
-				for k, v := range paramsExample {
-					paramsCopy[k] = v
-				}
-
-				as := "item"
-				if t["$as"] != nil {
-					if s, ok := t["$as"].(string); ok {
-						as = s
-					} else {
-						ctx.AddError(fmt.Errorf("error validating template: $as must be a string"))
-						return
-					}
-				}
-
-				paramsCopy[as] = item
-
-				loop := "loop"
-				if as != "item" {
-					loop += "_" + as
-				}
-				paramsCopy[loop] = map[string]interface{}{
-					"index": 0,
-					"first": true,
-					"last":  false,
-				}
-
-				// If the $each results in an array, we merge the items into the final
-				// array, allowing one $each to generate multiple outputs.
-				if a, ok := t["$each"].([]interface{}); ok {
-					for i, eachItem := range a {
-						validateTemplate(ctx.WithPath(fmt.Sprintf("$each/%d", i)), getItems(s), eachItem, paramsCopy)
-					}
-				} else {
-					if m, ok := t["$each"].(map[string]interface{}); ok {
-						parts := strings.Split(ctx.Path, "/")
-						if m["$for"] != nil && (len(parts) < 2 || parts[len(parts)-2] != "$each") {
-							// Special case: nested $for loops.
-							validateTemplate(ctx.WithPath("$each"), s, t["$each"], paramsCopy)
-							return
-						}
-					}
-					validateTemplate(ctx.WithPath("$each"), getItems(s), t["$each"], paramsCopy)
-				}
-			}
-			// TODO: disallow extra properties?
+		if t["$flatten"] != nil {
+			validateFlatten(ctx, s, t, paramsExample)
 			return
 		}
 	}


### PR DESCRIPTION
Rather than having magic behavior for `$for` loops returning arrays, this removes that "feature" in favor of an explicit `$flatten` operation that enables things like:

- Pre- and appending default values to arrays
- Zipper-merging `$for` loops that output arrays of items

This simplifies validation and rendering logic a bit. Docs are also updated.