### PR TITLE
feat: measure and warn if template complexity is high

### DIFF
--- a/context.go
+++ b/context.go
@@ -5,21 +5,22 @@ import (
 	"strings"
 )
 
-type errors struct {
-	Value []error
+type contextMeta struct {
+	Errors             []error
+	TemplateComplexity int
 }
 
 type context struct {
 	Filename string
 	Path     string
-	Errors   *errors
+	Meta     *contextMeta
 }
 
 func newContext(filename string, path ...string) *context {
 	return &context{
 		Filename: filename,
 		Path:     "/" + strings.Join(path, "/"),
-		Errors:   &errors{},
+		Meta:     &contextMeta{},
 	}
 }
 
@@ -27,7 +28,7 @@ func (c *context) WithPath(path interface{}) *context {
 	return &context{
 		Filename: c.Filename,
 		Path:     strings.TrimRight(c.Path, "/") + "/" + fmt.Sprintf("%v", path),
-		Errors:   c.Errors,
+		Meta:     c.Meta,
 	}
 }
 
@@ -46,6 +47,6 @@ func (c *context) FullPath() string {
 // AddError adds an error into the rendering context at the current path. As
 // a convenience it returns nil.
 func (c *context) AddError(err error) interface{} {
-	c.Errors.Value = append(c.Errors.Value, fmt.Errorf("%s: %w", c.FullPath(), err))
+	c.Meta.Errors = append(c.Meta.Errors, fmt.Errorf("%s: %w", c.FullPath(), err))
 	return nil
 }

--- a/fixtures_test.go
+++ b/fixtures_test.go
@@ -73,7 +73,8 @@ func TestFixtures(t *testing.T) {
 
 			for i, test := range f.Tests {
 				t.Run(fmt.Sprintf("%s-%d-%s", file.Name(), i, test.Name), func(t *testing.T) {
-					if test.ErrorsFail(t, f.Document.ValidateTemplate()) {
+					_, errs := f.Document.ValidateTemplate()
+					if test.ErrorsFail(t, errs) {
 						return
 					}
 


### PR DESCRIPTION
This uses each branch, loop, and interpolation to calculate a complexity value for a template, and then writes a warning to `os.Stderr` when that value is high (>50). This should help act as a warning to the user that maybe the template needs to be split into two separate templates (i.e. too many use-cases are being handled).